### PR TITLE
Refactored use of async. (#215)

### DIFF
--- a/WindowsDevicePortalWrapper/UnitTestProject/WDPMockImplementations/RestDelete.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/WDPMockImplementations/RestDelete.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
                 {
                     if (!response.IsSuccessStatusCode)
                     {
-                        throw new DevicePortalException(response);
+                        throw await DevicePortalException.CreateAsync(response);
                     }
 
                     if (response.Content != null)

--- a/WindowsDevicePortalWrapper/UnitTestProject/WDPMockImplementations/RestGet.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/WDPMockImplementations/RestGet.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
                 {
                     if (!response.IsSuccessStatusCode)
                     {
-                        throw new DevicePortalException(response);
+                        throw await DevicePortalException.CreateAsync(response);
                     }
 
                     using (HttpContent content = response.Content)

--- a/WindowsDevicePortalWrapper/UnitTestProject/WDPMockImplementations/RestPost.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/WDPMockImplementations/RestPost.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
                 {
                     if (!response.IsSuccessStatusCode)
                     {
-                        throw new DevicePortalException(response);
+                        throw await DevicePortalException.CreateAsync(response);
                     }
 
                     if (response.Content != null)

--- a/WindowsDevicePortalWrapper/UnitTestProject/WDPMockImplementations/RestPut.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/WDPMockImplementations/RestPut.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
                 {
                     if (!response.IsSuccessStatusCode)
                     {
-                        throw new DevicePortalException(response);
+                        throw await DevicePortalException.CreateAsync(response);
                     }
 
                     if (response.Content != null)

--- a/WindowsDevicePortalWrapper/UnitTestProject/WDPMockImplementations/WebSocket.cs
+++ b/WindowsDevicePortalWrapper/UnitTestProject/WDPMockImplementations/WebSocket.cs
@@ -116,22 +116,19 @@ namespace Microsoft.Tools.WindowsDevicePortal
                 while (this.keepListeningForMessages)
                 {
                     await webSocketTask.ConfigureAwait(false);
-                    webSocketTask.Wait();
 
                     using (HttpResponseMessage response = webSocketTask.Result)
                     {
                         if (!response.IsSuccessStatusCode)
                         {
-                            throw new DevicePortalException(response);
+                            throw await DevicePortalException.CreateAsync(response);
                         }
 
                         using (HttpContent content = response.Content)
                         {
                             MemoryStream dataStream = new MemoryStream();
 
-                            Task copyTask = content.CopyToAsync(dataStream);
-                            await copyTask.ConfigureAwait(false);
-                            copyTask.Wait();
+                            await content.CopyToAsync(dataStream).ConfigureAwait(false);
 
                             // Ensure we return with the stream pointed at the origin.
                             dataStream.Position = 0;
@@ -165,7 +162,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
             {
                 if (!response.IsSuccessStatusCode)
                 {
-                    throw new DevicePortalException(response);
+                    throw await DevicePortalException.CreateAsync(response);
                 }
             }
         }

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/Core/AppDeployment.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/Core/AppDeployment.cs
@@ -185,7 +185,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
 
                     await Task.Delay(TimeSpan.FromMilliseconds(stateCheckIntervalMs));
 
-                    status = await this.GetInstallStatusAsync();
+                    status = await this.GetInstallStatusAsync().ConfigureAwait(false);
                 }
                 while (status == ApplicationInstallStatus.InProgress);
 

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/Core/OsInformation.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/Core/OsInformation.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
         /// <returns>String containing the device's family.</returns>
         public async Task<string> GetDeviceFamilyAsync()
         {
-            DeviceOsFamily deviceFamily = await this.GetAsync<DeviceOsFamily>(DeviceFamilyApi);
+            DeviceOsFamily deviceFamily = await this.GetAsync<DeviceOsFamily>(DeviceFamilyApi).ConfigureAwait(false);
             return deviceFamily.Family;
         }
 
@@ -111,9 +111,9 @@ namespace Microsoft.Tools.WindowsDevicePortal
         /// Gets information about the device's operating system.
         /// </summary>
         /// <returns>OperatingSystemInformation object containing details of the installed operating system.</returns>
-        public async Task<OperatingSystemInformation> GetOperatingSystemInformationAsync()
+        public Task<OperatingSystemInformation> GetOperatingSystemInformationAsync()
         {
-            return await this.GetAsync<OperatingSystemInformation>(OsInfoApi);
+            return this.GetAsync<OperatingSystemInformation>(OsInfoApi);
         }
 
         /// <summary>
@@ -122,9 +122,9 @@ namespace Microsoft.Tools.WindowsDevicePortal
         /// <param name="name">The name to assign to the device.</param>
         /// <remarks>The new name does not take effect until the device has been restarted.</remarks>
         /// <returns>Task tracking setting the device name completion.</returns>
-        public async Task SetDeviceNameAsync(string name)
+        public Task SetDeviceNameAsync(string name)
         {
-            await this.PostAsync(
+            return this.PostAsync(
                 MachineNameApi,
                 string.Format("name={0}", Utilities.Hex64Encode(name)));
         }

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/DevicePortal.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/DevicePortal.cs
@@ -216,8 +216,8 @@ namespace Microsoft.Tools.WindowsDevicePortal
                     DeviceConnectionStatus.Connecting,
                     DeviceConnectionPhase.RequestingOperatingSystemInformation,
                     connectionPhaseDescription);
-                this.deviceConnection.Family = await this.GetDeviceFamilyAsync();
-                this.deviceConnection.OsInfo = await this.GetOperatingSystemInformationAsync();
+                this.deviceConnection.Family = await this.GetDeviceFamilyAsync().ConfigureAwait(false);
+                this.deviceConnection.OsInfo = await this.GetOperatingSystemInformationAsync().ConfigureAwait(false);
 
                 // Default to using whatever was specified in the connection.
                 bool requiresHttps = this.IsUsingHttps();
@@ -231,7 +231,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
                         DeviceConnectionStatus.Connecting,
                         DeviceConnectionPhase.DeterminingConnectionRequirements,
                         connectionPhaseDescription);
-                    requiresHttps = await this.GetIsHttpsRequiredAsync();
+                    requiresHttps = await this.GetIsHttpsRequiredAsync().ConfigureAwait(false);
                 }
 
                 // Connect the device to the specified network.
@@ -242,10 +242,10 @@ namespace Microsoft.Tools.WindowsDevicePortal
                         DeviceConnectionStatus.Connecting,
                         DeviceConnectionPhase.ConnectingToTargetNetwork,
                         connectionPhaseDescription);
-                    WifiInterfaces wifiInterfaces = await this.GetWifiInterfacesAsync();
+                    WifiInterfaces wifiInterfaces = await this.GetWifiInterfacesAsync().ConfigureAwait(false);
 
                     // TODO - consider what to do if there is more than one wifi interface on a device
-                    await this.ConnectToWifiNetworkAsync(wifiInterfaces.Interfaces[0].Guid, ssid, ssidKey);
+                    await this.ConnectToWifiNetworkAsync(wifiInterfaces.Interfaces[0].Guid, ssid, ssidKey).ConfigureAwait(false);
                 }
 
                 // Get the device's IP configuration and update the connection as appropriate.
@@ -268,7 +268,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
                     }
 
                     this.deviceConnection.UpdateConnection(
-                        await this.GetIpConfigAsync(), 
+                        await this.GetIpConfigAsync().ConfigureAwait(false), 
                         requiresHttps,
                         preservePort);
                 }
@@ -296,6 +296,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
                     while (innermostException.InnerException != null)
                     {
                         innermostException = innermostException.InnerException;
+                        await Task.Yield();
                     }
 
                     this.ConnectionFailedDescription = innermostException.Message;
@@ -372,16 +373,13 @@ namespace Microsoft.Tools.WindowsDevicePortal
 
                 websocket.WebSocketStreamReceived += streamReceivedHandler;
 
-                Task connect = websocket.ConnectAsync(endpoint);
-                connect.Wait();
+                await websocket.ConnectAsync(endpoint);
 
-                Task startListeningForStreamTask = websocket.ReceiveMessagesAsync();
-                startListeningForStreamTask.Wait();
+                await websocket.ReceiveMessagesAsync();
 
                 streamReceived.WaitOne();
 
-                Task stopListeningForStreamTask = websocket.CloseAsync();
-                stopListeningForStreamTask.Wait();
+                await websocket.CloseAsync();
 
                 websocket.WebSocketStreamReceived -= streamReceivedHandler;
 

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/HttpRest/RestGet.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/HttpRest/RestGet.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
 
             DataContractJsonSerializer serializer = new DataContractJsonSerializer(typeof(T));
 
-            using (Stream dataStream = await this.GetAsync(uri))
+            using (Stream dataStream = await this.GetAsync(uri).ConfigureAwait(false))
             {
                 if ((dataStream != null) &&
                     (dataStream.Length != 0))

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/IoT/BluetoothConnectivity.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/IoT/BluetoothConnectivity.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
         /// Gets the available bluetooth device information.
         /// </summary>
         /// <returns>List of Available bluetooth devices</returns>
-        public AvailableBluetoothDevicesInfo GetAvailableBluetoothDevicesInfo()
+        public async Task<AvailableBluetoothDevicesInfo> GetAvailableBluetoothDevicesInfoAsync()
         {
             AvailableBluetoothDevicesInfo bluetooth = null;
             ManualResetEvent bluetoothReceived = new ManualResetEvent(false);
@@ -87,13 +87,11 @@ namespace Microsoft.Tools.WindowsDevicePortal
                 };
             this.BluetoothDeviceListReceived += bluetoothReceivedHandler;
 
-            Task startListeningForBluetooth = this.StartListeningForBluetoothAsync(AvailableBluetoothDevicesApi);
-            startListeningForBluetooth.Wait();
+            await this.StartListeningForBluetoothAsync(AvailableBluetoothDevicesApi);
 
             bluetoothReceived.WaitOne();
 
-            Task stopListeningForBluetooth = this.StopListeningForBluetoothAsync();
-            stopListeningForBluetooth.Wait();
+            await this.StopListeningForBluetoothAsync();
 
             this.BluetoothDeviceListReceived -= bluetoothReceivedHandler;
             return bluetooth;
@@ -103,7 +101,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
         /// Gets the paired bluetooth device information.
         /// </summary>
         /// <returns>List of paired bluetooth devices</returns>
-        public PairedBluetoothDevicesInfo GetPairedBluetoothDevicesInfo()
+        public async Task<PairedBluetoothDevicesInfo> GetPairedBluetoothDevicesInfoAsync()
         {
             PairedBluetoothDevicesInfo bluetooth = null;
             ManualResetEvent pairedBluetoothReceived = new ManualResetEvent(false);
@@ -118,13 +116,11 @@ namespace Microsoft.Tools.WindowsDevicePortal
                 };
             this.PairedBluetoothDeviceListReceived += pairedBluetoothReceivedHandler;
 
-            Task startListeningForPairedBluetooth = this.StartListeningForPairedBluetoothAsync(PairedBluetoothDevicesApi);
-            startListeningForPairedBluetooth.Wait();
+            await this.StartListeningForPairedBluetoothAsync(PairedBluetoothDevicesApi);
 
             pairedBluetoothReceived.WaitOne();
 
-            Task stopListeningForPairedBluetooth = this.StopListeningForPairedBluetoothAsync();
-            stopListeningForPairedBluetooth.Wait();
+            await this.StopListeningForPairedBluetoothAsync();
 
             this.PairedBluetoothDeviceListReceived -= pairedBluetoothReceivedHandler;
             return bluetooth;
@@ -135,7 +131,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
         /// </summary>
         /// <param name="deviceId">Device Id.</param>
         /// <returns>Results of pairing a bluetooth device</returns>
-        public PairBluetoothDevicesInfo GetPairBluetoothDevicesInfo(string deviceId)
+        public async Task<PairBluetoothDevicesInfo> GetPairBluetoothDevicesInfoAsync(string deviceId)
         {
             PairBluetoothDevicesInfo bluetooth = null;
             ManualResetEvent pairBluetoothReceived = new ManualResetEvent(false);
@@ -150,13 +146,11 @@ namespace Microsoft.Tools.WindowsDevicePortal
                 };
             this.PairBluetoothDeviceListReceived += pairBluetoothReceivedHandler;
 
-            Task startListeningForPairBluetooth = this.StartListeningForPairBluetoothAsync(PairBluetoothDevicesApi, string.Format("deviceId={0}", Utilities.Hex64Encode(deviceId)));
-            startListeningForPairBluetooth.Wait();
+            await this.StartListeningForPairBluetoothAsync(PairBluetoothDevicesApi, string.Format("deviceId={0}", Utilities.Hex64Encode(deviceId)));
 
             pairBluetoothReceived.WaitOne();
 
-            Task stopListeningForPairBluetooth = this.StopListeningForPairBluetoothAsync();
-            stopListeningForPairBluetooth.Wait();
+            await this.StopListeningForPairBluetoothAsync();
 
             this.PairBluetoothDeviceListReceived -= pairBluetoothReceivedHandler;
             return bluetooth;

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/Xbox/XboxAppDeployment.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/Xbox/XboxAppDeployment.cs
@@ -40,15 +40,15 @@ namespace Microsoft.Tools.WindowsDevicePortal
 
             await this.PostAsync(
                 RegisterPackageApi,
-                string.Format("folder={0}", Utilities.Hex64Encode(folderName)));
+                string.Format("folder={0}", Utilities.Hex64Encode(folderName))).ConfigureAwait(false);
 
             // Poll the status until complete.
             ApplicationInstallStatus status = ApplicationInstallStatus.InProgress;
             do
             {
-                await Task.Delay(TimeSpan.FromMilliseconds(500));
+                await Task.Delay(TimeSpan.FromMilliseconds(500)).ConfigureAwait(false);
 
-                status = await this.GetInstallStatusAsync();
+                status = await this.GetInstallStatusAsync().ConfigureAwait(false);
             }
             while (status == ApplicationInstallStatus.InProgress);
         }

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/CertificateHandling.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/CertificateHandling.cs
@@ -43,24 +43,11 @@ namespace Microsoft.Tools.WindowsDevicePortal
             using (HttpClient client = new HttpClient(requestSettings))
             {
                 this.ApplyHttpHeaders(client, HttpMethods.Get);
-
-                IAsyncOperationWithProgress<HttpResponseMessage, HttpProgress> responseOperation = client.GetAsync(uri);
-                TaskAwaiter<HttpResponseMessage> responseAwaiter = responseOperation.GetAwaiter();
-                while (!responseAwaiter.IsCompleted)
-                { 
-                }
-
-                using (HttpResponseMessage response = responseOperation.GetResults())
+                using (HttpResponseMessage response = await client.GetAsync(uri))
                 {
                     using (IHttpContent messageContent = response.Content)
                     {
-                        IAsyncOperationWithProgress<IBuffer, ulong> bufferOperation = messageContent.ReadAsBufferAsync();
-                        TaskAwaiter<IBuffer> readBufferAwaiter = bufferOperation.GetAwaiter();
-                        while (!readBufferAwaiter.IsCompleted)
-                        { 
-                        }
-
-                        certificate = new Certificate(bufferOperation.GetResults());
+                        certificate = new Certificate(await messageContent.ReadAsBufferAsync());
                     }
                 }
             }

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/Core/AppDeployment.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/Core/AppDeployment.cs
@@ -53,12 +53,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
             {
                 this.ApplyHttpHeaders(client, HttpMethods.Get);
 
-                IAsyncOperationWithProgress<HttpResponseMessage, HttpProgress> responseOperation = client.GetAsync(uri);
-                while (responseOperation.Status != AsyncStatus.Completed)
-                { 
-                }
-
-                using (HttpResponseMessage response = responseOperation.GetResults())
+                using (HttpResponseMessage response = await client.GetAsync(uri))
                 {
                     if (response.IsSuccessStatusCode)
                     {
@@ -72,12 +67,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
                                 IBuffer dataBuffer = null;
                                 using (IHttpContent messageContent = response.Content)
                                 {
-                                    IAsyncOperationWithProgress<IBuffer, ulong> bufferOperation = messageContent.ReadAsBufferAsync();
-                                    while (bufferOperation.Status != AsyncStatus.Completed)
-                                    {
-                                    }
-
-                                    dataBuffer = bufferOperation.GetResults();
+                                    dataBuffer = await messageContent.ReadAsBufferAsync();
 
                                     if (dataBuffer != null)
                                     {
@@ -114,7 +104,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
                     }
                     else
                     {
-                        throw new DevicePortalException(response);
+                        throw await DevicePortalException.CreateAsync(response);
                     }
                 }
             }

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/HttpRest/RestDelete.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/HttpRest/RestDelete.cs
@@ -45,30 +45,18 @@ namespace Microsoft.Tools.WindowsDevicePortal
             using (HttpClient client = new HttpClient(httpFilter))
             {
                 this.ApplyHttpHeaders(client, HttpMethods.Delete);
-
-                IAsyncOperationWithProgress<HttpResponseMessage, HttpProgress> responseOperation = client.DeleteAsync(uri);
-                TaskAwaiter<HttpResponseMessage> responseAwaiter = responseOperation.GetAwaiter();
-                while (!responseAwaiter.IsCompleted)
-                { 
-                }
-
-                using (HttpResponseMessage response = responseOperation.GetResults())
+                using (HttpResponseMessage response = await client.DeleteAsync(uri))
                 {
                     if (!response.IsSuccessStatusCode)
                     {
-                        throw new DevicePortalException(response);
+                        throw await DevicePortalException.CreateAsync(response);
                     }
 
                     if (response.Content != null)
                     {
                         using (IHttpContent messageContent = response.Content)
                         {
-                            IAsyncOperationWithProgress<IBuffer, ulong> bufferOperation = messageContent.ReadAsBufferAsync();
-                            while (bufferOperation.Status != AsyncStatus.Completed)
-                            {
-                            }
-
-                            dataBuffer = bufferOperation.GetResults();
+                            dataBuffer = await messageContent.ReadAsBufferAsync();
                         }
                     }
                 }

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/HttpRest/RestGet.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/HttpRest/RestGet.cs
@@ -45,28 +45,16 @@ namespace Microsoft.Tools.WindowsDevicePortal
             using (HttpClient client = new HttpClient(requestSettings))
             {
                 this.ApplyHttpHeaders(client, HttpMethods.Get);
-
-                IAsyncOperationWithProgress<HttpResponseMessage, HttpProgress> responseOperation = client.GetAsync(uri);
-                TaskAwaiter<HttpResponseMessage> responseAwaiter = responseOperation.GetAwaiter();
-                while (!responseAwaiter.IsCompleted)
-                { 
-                }
-
-                using (HttpResponseMessage response = responseOperation.GetResults())
+                using (HttpResponseMessage response = await client.GetAsync(uri))
                 {
                     if (!response.IsSuccessStatusCode)
                     {
-                        throw new DevicePortalException(response);
+                        throw await DevicePortalException.CreateAsync(response);
                     }
 
                     using (IHttpContent messageContent = response.Content)
                     {
-                        IAsyncOperationWithProgress<IBuffer, ulong> bufferOperation = messageContent.ReadAsBufferAsync();
-                        while (bufferOperation.Status != AsyncStatus.Completed)
-                        { 
-                        }
-
-                        dataBuffer = bufferOperation.GetResults();
+                        dataBuffer = await messageContent.ReadAsBufferAsync();
                     }
                 }
             }

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/HttpRest/RestPost.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/HttpRest/RestPost.cs
@@ -58,30 +58,18 @@ namespace Microsoft.Tools.WindowsDevicePortal
             using (HttpClient client = new HttpClient(httpFilter))
             {
                 this.ApplyHttpHeaders(client, HttpMethods.Post);
-
-                IAsyncOperationWithProgress<HttpResponseMessage, HttpProgress> responseOperation = client.PostAsync(uri, requestContent);
-                TaskAwaiter<HttpResponseMessage> responseAwaiter = responseOperation.GetAwaiter();
-                while (!responseAwaiter.IsCompleted)
-                {
-                }
-
-                using (HttpResponseMessage response = responseOperation.GetResults())
+                using (HttpResponseMessage response = await client.PostAsync(uri, requestContent))
                 {
                     if (!response.IsSuccessStatusCode)
                     {
-                        throw new DevicePortalException(response);
+                        throw await DevicePortalException.CreateAsync(response);
                     }
 
                     if (response.Content != null)
                     {
                         using (IHttpContent messageContent = response.Content)
                         {
-                            IAsyncOperationWithProgress<IBuffer, ulong> bufferOperation = messageContent.ReadAsBufferAsync();
-                            while (bufferOperation.Status != AsyncStatus.Completed)
-                            {
-                            }
-
-                            dataBuffer = bufferOperation.GetResults();
+                            dataBuffer = await messageContent.ReadAsBufferAsync();
                         }
                     }
                 }

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/HttpRest/RestPut.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/HttpRest/RestPut.cs
@@ -50,29 +50,18 @@ namespace Microsoft.Tools.WindowsDevicePortal
                 this.ApplyHttpHeaders(client, HttpMethods.Put);
 
                 // Send the request
-                IAsyncOperationWithProgress<HttpResponseMessage, HttpProgress> responseOperation = client.PutAsync(uri, null);
-                TaskAwaiter<HttpResponseMessage> responseAwaiter = responseOperation.GetAwaiter();
-                while (!responseAwaiter.IsCompleted)
-                { 
-                }
-
-                using (HttpResponseMessage response = responseOperation.GetResults())
+                using (HttpResponseMessage response = await client.PutAsync(uri, null))
                 {
                     if (!response.IsSuccessStatusCode)
                     {
-                        throw new DevicePortalException(response);
+                        throw await DevicePortalException.CreateAsync(response);
                     }
 
                     if (response.Content != null)
                     {
                         using (IHttpContent messageContent = response.Content)
                         {
-                            IAsyncOperationWithProgress<IBuffer, ulong> bufferOperation = messageContent.ReadAsBufferAsync();
-                            while (bufferOperation.Status != AsyncStatus.Completed)
-                            {
-                            }
-
-                            dataBuffer = bufferOperation.GetResults();
+                            dataBuffer = await messageContent.ReadAsBufferAsync();
                         }
                     }
                 }

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/HttpRest/WebSocket.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.UniversalWindows/HttpRest/WebSocket.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
         /// </summary>
         /// <param name="sender">The  <see cref="MessageWebSocket" /> that sent the message.</param>
         /// <param name="args">The message from the web socket.</param>
-        private void MessageReceived(MessageWebSocket sender, MessageWebSocketMessageReceivedEventArgs args)
+        private async void MessageReceived(MessageWebSocket sender, MessageWebSocketMessageReceivedEventArgs args)
         {
             if (this.IsListeningForMessages)
             {
@@ -121,8 +121,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
                 {
                     Stream stream = new MemoryStream();
 
-                    Task copyTask = inputStream.AsStreamForRead().CopyToAsync(stream);
-                    copyTask.Wait();
+                    await inputStream.AsStreamForRead().CopyToAsync(stream);
 
                     // Ensure we return with the stream pointed at the origin.
                     stream.Position = 0;

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/Core/AppDeployment.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/Core/AppDeployment.cs
@@ -39,12 +39,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
             using (HttpClient client = new HttpClient(handler))
             {
                 this.ApplyHttpHeaders(client, HttpMethods.Get);
-
-                Task<HttpResponseMessage> getTask = client.GetAsync(uri);
-                await getTask.ConfigureAwait(false);
-                getTask.Wait();
-
-                using (HttpResponseMessage response = getTask.Result)
+                using (HttpResponseMessage response = await client.GetAsync(uri).ConfigureAwait(false))
                 {
                     if (response.IsSuccessStatusCode)
                     {
@@ -64,9 +59,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
                                 {
                                     dataStream = new MemoryStream();
 
-                                    Task copyTask = content.CopyToAsync(dataStream);
-                                    await copyTask.ConfigureAwait(false);
-                                    copyTask.Wait();
+                                    await content.CopyToAsync(dataStream).ConfigureAwait(false);
 
                                     // Ensure we point the stream at the origin.
                                     dataStream.Position = 0;
@@ -101,7 +94,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
                     }
                     else
                     {
-                        throw new DevicePortalException(response);
+                        throw await DevicePortalException.CreateAsync(response);
                     }
                 }
             }

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/RestDelete.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/RestDelete.cs
@@ -35,15 +35,11 @@ namespace Microsoft.Tools.WindowsDevicePortal
             {
                 this.ApplyHttpHeaders(client, HttpMethods.Delete);
 
-                Task<HttpResponseMessage> deleteTask = client.DeleteAsync(uri);
-                await deleteTask.ConfigureAwait(false);
-                deleteTask.Wait();
-
-                using (HttpResponseMessage response = deleteTask.Result)
+                using (HttpResponseMessage response = await client.DeleteAsync(uri).ConfigureAwait(false))
                 {
                     if (!response.IsSuccessStatusCode)
                     {
-                        throw new DevicePortalException(response);
+                        throw await DevicePortalException.CreateAsync(response);
                     }
 
                     if (response.Content != null)
@@ -52,9 +48,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
                         {
                             dataStream = new MemoryStream();
 
-                            Task copyTask = content.CopyToAsync(dataStream);
-                            await copyTask.ConfigureAwait(false);
-                            copyTask.Wait();
+                            await content.CopyToAsync(dataStream).ConfigureAwait(false);
 
                             // Ensure we return with the stream pointed at the origin.
                             dataStream.Position = 0;

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/RestGet.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/RestGet.cs
@@ -35,24 +35,18 @@ namespace Microsoft.Tools.WindowsDevicePortal
             {
                 this.ApplyHttpHeaders(client, HttpMethods.Get);
 
-                Task<HttpResponseMessage> getTask = client.GetAsync(uri);
-                await getTask.ConfigureAwait(false);
-                getTask.Wait();
-
-                using (HttpResponseMessage response = getTask.Result)
+                using (HttpResponseMessage response = await client.GetAsync(uri).ConfigureAwait(false))
                 {
                     if (!response.IsSuccessStatusCode)
                     {
-                        throw new DevicePortalException(response);
+                        throw await DevicePortalException.CreateAsync(response);
                     }
 
                     using (HttpContent content = response.Content)
                     {
                         dataStream = new MemoryStream();
 
-                        Task copyTask = content.CopyToAsync(dataStream);
-                        await copyTask.ConfigureAwait(false);
-                        copyTask.Wait();
+                        await content.CopyToAsync(dataStream).ConfigureAwait(false);
 
                         // Ensure we return with the stream pointed at the origin.
                         dataStream.Position = 0;

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/RestPost.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/RestPost.cs
@@ -48,15 +48,11 @@ namespace Microsoft.Tools.WindowsDevicePortal
             {
                 this.ApplyHttpHeaders(client, HttpMethods.Post);
 
-                Task<HttpResponseMessage> postTask = client.PostAsync(uri, requestContent);
-                await postTask.ConfigureAwait(false);
-                postTask.Wait();
-
-                using (HttpResponseMessage response = postTask.Result)
+                using (HttpResponseMessage response = await client.PostAsync(uri, requestContent).ConfigureAwait(false))
                 {
                     if (!response.IsSuccessStatusCode)
                     {
-                        throw new DevicePortalException(response);
+                        throw await DevicePortalException.CreateAsync(response);
                     }
 
                     if (response.Content != null)
@@ -65,9 +61,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
                         {
                             responseDataStream = new MemoryStream();
 
-                            Task copyTask = responseContent.CopyToAsync(responseDataStream);
-                            await copyTask.ConfigureAwait(false);
-                            copyTask.Wait();
+                            await responseContent.CopyToAsync(responseDataStream).ConfigureAwait(false);
 
                             // Ensure we return with the stream pointed at the origin.
                             responseDataStream.Position = 0;

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/RestPut.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/RestPut.cs
@@ -39,15 +39,11 @@ namespace Microsoft.Tools.WindowsDevicePortal
                 this.ApplyHttpHeaders(client, HttpMethods.Put);
 
                 // Send the request
-                Task<HttpResponseMessage> putTask = client.PutAsync(uri, body);
-                await putTask.ConfigureAwait(false);
-                putTask.Wait();
-
-                using (HttpResponseMessage response = putTask.Result)
+                using (HttpResponseMessage response = await client.PutAsync(uri, body).ConfigureAwait(false))
                 {
                     if (!response.IsSuccessStatusCode)
                     {
-                        throw new DevicePortalException(response);
+                        throw await DevicePortalException.CreateAsync(response);
                     }
 
                     if (response.Content != null)
@@ -56,9 +52,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
                         {
                             dataStream = new MemoryStream();
 
-                            Task copyTask = content.CopyToAsync(dataStream);
-                            await copyTask.ConfigureAwait(false);
-                            copyTask.Wait();
+                            await content.CopyToAsync(dataStream).ConfigureAwait(false);
 
                             // Ensure we return with the stream pointed at the origin.
                             dataStream.Position = 0;

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/WebSocket.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper/HttpRest/WebSocket.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
 
                             do
                             {
-                                result = await this.websocket.ReceiveAsync(buffer, CancellationToken.None);
+                                result = await this.websocket.ReceiveAsync(buffer, CancellationToken.None).ConfigureAwait(false);
 
                                 if (result.MessageType == WebSocketMessageType.Close)
                                 {


### PR DESCRIPTION
* Refactored use of async. No tight while-loops but instead using await and continue on background threads.

* Remove use of .Wait() to avoid potential deadlocks. increase use of ConfigureAwait, and remove await where not needed

* Simplified async code. Instead of forwarding to tasks and have to switch to ui thread, it's easier to just await and continue on the same thread here.